### PR TITLE
Change logging

### DIFF
--- a/bimmer_connected/state.py
+++ b/bimmer_connected/state.py
@@ -70,7 +70,7 @@ def backend_parameter(func):
         try:
             return func(self, *args, **kwargs)
         except KeyError:
-            _LOGGER.error('No data available for attribute %s!', str(func))
+            _LOGGER.debug('No data available for attribute %s!', str(func))
             return None
     return _func_wrapper
 


### PR DESCRIPTION
Currently the log will show errors every 5 minutes in case specific data is not found, see [this](https://github.com/home-assistant/home-assistant/issues/16631) HA issue.
This changes the logging from `error` to `debug` mode, so the log doesn't get flooded with this messages.