### PR TITLE
added parsing of CCM

### DIFF
--- a/bimmer_connected/state.py
+++ b/bimmer_connected/state.py
@@ -342,11 +342,7 @@ class VehicleState:  # pylint: disable=too-many-public-methods
     @property
     @backend_parameter
     def check_control_messages(self) -> List[CheckControlMessage]:
-        """List of check control messages.
-
-        Right now they are not parsed, as we do not have sample data with CC messages.
-        See issue https://github.com/m1n3rva/bimmer_connected/issues/55
-        """
+        """List of check control messages."""
         messages = self._attributes.get('checkControlMessages', [])
         return [CheckControlMessage(m) for m in messages]
 

--- a/bimmer_connected/state.py
+++ b/bimmer_connected/state.py
@@ -58,6 +58,36 @@ class ChargingState(Enum):
     WAITING_FOR_CHARGING = 'WAITING_FOR_CHARGING'
 
 
+class CheckControlMessage:
+    """Check control message sent from the server.
+
+    This class provides a nicer API than parsing the JSON format directly.
+    """
+
+    def __init__(self, ccm_dict: dict):
+        self._ccm_dict = ccm_dict
+
+    @property
+    def description_long(self) -> str:
+        """Long description of the check control message."""
+        return self._ccm_dict["ccmDescriptionLong"]
+
+    @property
+    def description_short(self) -> str:
+        """Short description of the check control message."""
+        return self._ccm_dict["ccmDescriptionShort"]
+
+    @property
+    def ccm_id(self) -> int:
+        """id of the check control message."""
+        return int(self._ccm_dict["ccmId"])
+
+    @property
+    def mileage(self) -> int:
+        """Mileage of the vehicle when the check control message appeared."""
+        return int(self._ccm_dict["ccmMileage"])
+
+
 def backend_parameter(func):
     """Decorator for parameters reading data from the backend.
 
@@ -311,13 +341,14 @@ class VehicleState:  # pylint: disable=too-many-public-methods
 
     @property
     @backend_parameter
-    def check_control_messages(self) -> List:
+    def check_control_messages(self) -> List[CheckControlMessage]:
         """List of check control messages.
 
         Right now they are not parsed, as we do not have sample data with CC messages.
         See issue https://github.com/m1n3rva/bimmer_connected/issues/55
         """
-        return self._attributes.get('checkControlMessages', [])
+        messages = self._attributes.get('checkControlMessages', [])
+        return [CheckControlMessage(m) for m in messages]
 
     @property
     @backend_parameter

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -185,7 +185,7 @@ class TestState(unittest.TestCase):
         state._attributes['windowDriverFront'] = LidState.INTERMEDIATE
         self.assertFalse(state.all_windows_closed)
 
-    def test_windows_g48(self):
+    def test_windows_f48(self):
         """Test features around lids."""
         account = unittest.mock.MagicMock(ConnectedDriveAccount)
         state = VehicleState(account, None)
@@ -239,3 +239,18 @@ class TestState(unittest.TestCase):
                     self.assertTrue(vehicle.state.has_check_control_messages)
                 else:
                     self.assertFalse(vehicle.state.has_check_control_messages)
+
+    def test_ccm_f48(self):
+        """Test parsing of a check control message."""
+        account = unittest.mock.MagicMock(ConnectedDriveAccount)
+        state = VehicleState(account, None)
+        state._attributes = F48_TEST_DATA['vehicleStatus']
+
+        ccms = state.check_control_messages
+        self.assertEqual(1, len(ccms))
+
+        ccm = ccms[0]
+        self.assertEqual(955, ccm.ccm_id)
+        self.assertEqual(41544, ccm.mileage)
+        self.assertIn("Tyre pressure", ccm.description_short)
+        self.assertIn("continue driving", ccm.description_long)


### PR DESCRIPTION
As we now have new data(https://github.com/m1n3rva/bimmer_connected/issues/55), we can also parse the Check Control Messages into Python objects.

I added a new class `Check_Control_Message` in `state.py` providing a nicer access to the data sent from the server. Also added tests for this...

